### PR TITLE
beta sheet segment added if last residue is in beta conformation

### DIFF
--- a/src/pyPept/conformer.py
+++ b/src/pyPept/conformer.py
@@ -302,7 +302,10 @@ class Conformer:
         if len(segments) == 2 and len(segments[0]) == len(segments[1]):
             for i, ele in enumerate(segments[0]):
                 ind_o = backbone_atoms[ele][-1]
-                ind_n = backbone_atoms[segments[1][(i + 1) * -1]][0]
+                try:
+                    ind_n = backbone_atoms[segments[1][(i + 1) * -1]][0]
+                except IndexError:
+                    continue
                 bounds[ind_o, ind_n] = 3.2
 
         # Generate the new distance matrix and predict the conformer

--- a/src/pyPept/conformer.py
+++ b/src/pyPept/conformer.py
@@ -313,7 +313,7 @@ class Conformer:
             parameters.SetBoundsMat(bounds)
             parameters.useRandomCoords = True
             AllChem.EmbedMolecule(romol, parameters)
-            AllChem.UFFOptimizeMolecule(romol)
+            # AllChem.UFFOptimizeMolecule(romol)
             pdb_mol = Chem.MolToPDBBlock(romol)
         except FileExistsError:
             warnings.warn("Failed to generate the conformer in RDKit")

--- a/src/pyPept/conformer.py
+++ b/src/pyPept/conformer.py
@@ -296,6 +296,8 @@ class Conformer:
                     segments.append(fragment)
                     flag = 0
                 fragment = []
+        if len(fragment) > 0:
+            segments.append(fragment)
 
         if len(segments) == 2 and len(segments[0]) == len(segments[1]):
             for i, ele in enumerate(segments[0]):


### PR DESCRIPTION
When the secondary structure contains two beta segments and the secondary structure ends with E (e.g. EEEEBEEEE) the algorithm ignores the last segment. This pull request aims to fix that.