### PR TITLE
Fix pandas 2.x ValueError in monomer SDF loading

### DIFF
--- a/src/pyPept/monomerlib.py
+++ b/src/pyPept/monomerlib.py
@@ -109,6 +109,10 @@ class MonomerLibrary:
             MonomerConstants.attr_linkable_R_group_attachidx,
             ]
 
+        # Pandas 2.x uses Arrow-backed string columns that reject list assignment.
+        # Cast only the three list-valued columns to object dtype before writing.
+        for group in groups:
+            df_group[group] = df_group[group].astype(object)
         for idx in df_group.index:
             for group in groups:
                 change = df_group[group][idx].split(
@@ -119,7 +123,7 @@ class MonomerLibrary:
                 else:
                     updated_change = [
                         None if v == 'None' else int(v) for v in change]
-                df_group.loc[idx, group] = updated_change
+                df_group.at[idx, group] = updated_change
         df_group = df_group.set_index('symbol')
         df_group = df_group.rename(columns={"ROMol": "m_romol"})
 

--- a/src/pyPept/sequence.py
+++ b/src/pyPept/sequence.py
@@ -525,6 +525,10 @@ def get_monomer_info(path):
     df_group = PandasTools.LoadSDF(sdf_file)
 
     groups = ['m_Rgroups', 'm_RgroupIdx', 'm_attachmentPointIdx']
+    # Pandas 2.x uses Arrow-backed string columns that reject list assignment.
+    # Cast only the three list-valued columns to object dtype before writing.
+    for group in groups:
+        df_group[group] = df_group[group].astype(object)
     for idx in df_group.index:
         for group in groups:
             change = df_group[group][idx].split(SequenceConstants.csv_separator)
@@ -533,7 +537,7 @@ def get_monomer_info(path):
             else:
                 updated_change = [None if v == 'None' else int(v) for v in
                                   change]
-            df_group.loc[idx, group] = updated_change
+            df_group.at[idx, group] = updated_change
     df_group = df_group.set_index('symbol')
     df_group = df_group.rename(columns={"ROMol": "m_romol"})
 


### PR DESCRIPTION
## Summary

Fixes #18

Pandas 2.x introduced Arrow-backed storage for string columns. When
`get_monomer_info()` and `_load_monomer_sdf()` attempt to write a parsed
Python list into these columns via `df.loc[idx, col] = [...]`, pandas 2.x
raises:

    ValueError: Must have equal len keys and value when setting with an iterable

because it interprets the list as multiple row values rather than a single
list object for one cell.

## Fix

Two changes, applied in both `sequence.py` and `monomerlib.py`:

1. Cast the three list-valued columns (`m_Rgroups`, `m_RgroupIdx`,
   `m_attachmentPointIdx`) to `object` dtype before writing into them.
   Only these three columns are cast — the rest of the DataFrame retains
   its pandas 2.x type optimisations.

2. Use `df.at[idx, col]` (single-cell assignment) instead of
   `df.loc[idx, col]` (which pandas 2.x misinterprets as a broadcast
   when given an iterable).

## Note on duplication

`get_monomer_info()` in `sequence.py` and `_load_monomer_sdf()` in
`monomerlib.py` implement the same SDF loading and list-parsing logic
independently. This fix is applied to both. A follow-up refactor could
consolidate them into a single shared loader to avoid this kind of
divergence in future — happy to open a separate PR for that if useful.