### PR TITLE
Fix D_Phg_ol m_name: copy-paste error from Aib_ol

### DIFF
--- a/src/pyPept/data/monomers.sdf
+++ b/src/pyPept/data/monomers.sdf
@@ -11371,10 +11371,10 @@ $$$$
 M  RGP  1  11   1
 V   11 *
 M  END
->  <m_name>  (189) 
-2-amino-2-methylpropan-1-ol
+>  <m_name>  (189)
+(2R)-2-amino-2-phenylethan-1-ol
 
->  <symbol>  (189) 
+>  <symbol>  (189)
 D_Phg_ol
 
 >  <m_abbr>  (189) 


### PR DESCRIPTION
Closes PistoiaHELM/HELMMonomerSets#7

## Bug

The `D_Phg_ol` monomer in `src/pyPept/data/monomers.sdf` has an incorrect `m_name` field:

| Field | Current (wrong) | Correct |
|-------|----------------|---------|
| `m_abbr` | `D_Phg_ol` | `D_Phg_ol` ✓ |
| SMILES | `[1*]NC(CO)c1ccccc1` | `[1*]NC(CO)c1ccccc1` ✓ |
| `m_name` | `2-amino-2-methylpropan-1-ol` ✗ | `(2R)-2-amino-2-phenylethan-1-ol` ✓ |

The SMILES contains a benzene ring and is unambiguously (2R)-2-amino-2-phenylethan-1-ol (D-phenylglycinol, C₈H₁₁NO). The name `2-amino-2-methylpropan-1-ol` belongs to `Aib_ol` (C₄H₁₁NO, no aromatic ring) — a copy-paste error.

The naming convention is consistent with the L-form: `Phg_ol` is correctly named `(2S)-2-amino-2-phenylethan-1-ol`.

## Origin

The pyPept monomer library derives its 322-entry set from the PistoiaHELM HELMCoreLibrary, where this error originates. A corresponding fix has been submitted upstream: https://github.com/PistoiaHELM/HELMMonomerSets/pull/10